### PR TITLE
clrtrust-helper.c: use int c instead of char c

### DIFF
--- a/clrtrust-helper.c
+++ b/clrtrust-helper.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     unsigned long subject_hash;
 
     unsigned int i;
-    char c;
+    int c;
 
     char *fname = NULL;
     size_t sz = 0;


### PR DESCRIPTION
getopt returns an int rather than a char. We should we not be relying on
automatic type casting. Further, some compilers have char as unsigned
which will break the program at the ((c = getopt(argc, argv, "fs")) != -1)
evaluation with default compiler options.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>